### PR TITLE
Fix safe_parse_json error handling

### DIFF
--- a/etl/question_reconstruction.py
+++ b/etl/question_reconstruction.py
@@ -129,7 +129,9 @@ def safe_parse_json(text: str) -> List[Dict[str, Any]]:
             if isinstance(data, list):
                 return data
         except Exception:
-            raise ValueError("Response could not be parsed as a list of questions")
+            pass
+    # If we reach here, parsing failed
+    raise ValueError("Response could not be parsed as a list of questions")
 
 def run_batch_with_retries(messages, batch_index, retries=3, delay=30):
     for attempt in range(retries):


### PR DESCRIPTION
## Summary
- improve fallback logic in `safe_parse_json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_683ff21dea48832f9346e2ba488ee723